### PR TITLE
Fix dtype chages for types array

### DIFF
--- a/robo/models/random_forest.py
+++ b/robo/models/random_forest.py
@@ -56,8 +56,8 @@ class RandomForest(BaseModel):
                  max_num_nodes=10,
                  seed=42):
 
-        self.types = types
-        self.types.dtype = np.uint
+        # make sure types are uint
+        self.types = np.array(types, dtype=np.uint)
 
         self.rf = pyrfr.regression.binary_rss()
         self.rf.num_trees = num_trees

--- a/robo/task/base_task.py
+++ b/robo/task/base_task.py
@@ -53,11 +53,9 @@ class BaseTask(object):
         assert self.n_dims == self.X_upper.shape[0]
 
         if types is None:
-            self.types = np.zeros([self.n_dims])
-            self.types.dtype = np.uint
+            self.types = np.zeros([self.n_dims], dtype=np.uint)
         else:
-            self.types = types
-            self.types.dtype = np.uint
+            self.types = np.array(types, dtype=np.uint)
 
         self.opt = opt
         self.fopt = fopt


### PR DESCRIPTION
You need to be carefull with simply changing .dtype of a numpy array
this will NOT cast the value but rather just re-interpred the storage.
I guess what you wanted was casting and changed it.