### PR TITLE
Correcting initial design of FABOLAS

### DIFF
--- a/robo/initial_design/extrapolative_initial_design.py
+++ b/robo/initial_design/extrapolative_initial_design.py
@@ -9,11 +9,15 @@ import numpy as np
 from robo.initial_design.init_random_uniform import init_random_uniform
 
 
-def extrapolative_initial_design(X_lower, X_upper, is_env, N):
+def extrapolative_initial_design(X_lower, X_upper, is_env, task, N):
 
     # Create grid for the system size
     idx = is_env == 1
-    g = np.array([X_upper[idx] / float(i) for i in [4, 8, 16, 32]])[:, 0]
+    X_upper_re = np.exp(task.retransform(X_upper))
+
+    g = np.array([X_upper_re[idx] / float(i) for i in [4, 8, 16, 32]])[:, 0]
+    g = np.true_divide((np.log(g) - task.original_X_lower[idx]),
+           (task.original_X_upper[idx] - task.original_X_lower[idx]))
 
     X = init_random_uniform(X_lower, X_upper, N)
 

--- a/robo/solver/fabolas.py
+++ b/robo/solver/fabolas.py
@@ -145,6 +145,7 @@ class Fabolas(BayesianOptimization):
             init = extrapolative_initial_design(self.task.X_lower,
                                        self.task.X_upper,
                                        self.task.is_env,
+                                       self.task,
                                        N=self.init_points)
 
             for i, x in enumerate(init):
@@ -154,6 +155,7 @@ class Fabolas(BayesianOptimization):
                 logger.info("Evaluate: %s" % x)
 
                 start_time = time.time()
+
                 y, c = self.task.evaluate(x)
 
                 # Transform cost to log scale


### PR DESCRIPTION
Correcting initial design of FABOLAS to actually perform trials on 1/4th, 1/8th1/16th, and 1/32th of the actual dataset. Without this fix, the size of the subset is computed in log-space, which results in considerable smaller subsets.