### PR TITLE
Fix dead link to pyrfr

### DIFF
--- a/all_requirements.txt
+++ b/all_requirements.txt
@@ -9,5 +9,5 @@ theano
 lasagne
 git+https://github.com/sfalkner/george.git
 git+https://github.com/stokasto/sgmcmc.git
-git+https://bitbucket.org/aadfreiburg/random_forest_run
+git+https://github.com/automl/random_forest_run.git
 git+https://github.com/automl/HPOlib2.git


### PR DESCRIPTION
The old address for `pyrfr` in `all_requirements.txt` now returns a 404. I fixed it to point to the new location of the repo on github.