### PR TITLE
add gfortran to package dependencies to build DIRECT

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -32,7 +32,7 @@ RoBO uses the Gaussian processes library `george <https://github.com/dfm/george>
 
 .. code:: bash
 
-     sudo apt-get install libeigen3-dev swig
+     sudo apt-get install libeigen3-dev swig gfortran
 
 then change into the new directory:
 

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -39,7 +39,7 @@ To use RoBO we have to define a function that symbolizes the objective function 
     		y = np.sin(3 * x[0]) * 4 * (x[0] - 1) * (x[0] + 2)
     		return y
 
-Before we run Bayesian optimization we first have to define the lower and upper bound of our input search space. In this case our search space contains only one dimension, but Bayesian optimization is not restricted to that and normally works find up to 10 (continuous) dimensions.
+Before we run Bayesian optimization we first have to define the lower and upper bound of our input search space. In this case our search space contains only one dimension, but Bayesian optimization is not restricted to that and normally works fine up to 10 (continuous) dimensions.
 
     .. code-block:: python
 	


### PR DESCRIPTION
Looks like this is required.
It looks like you've also checked in the generated html, I haven't updated that.