### PR TITLE
Make random forest model pickle-able

### DIFF
--- a/robo/models/random_forest.py
+++ b/robo/models/random_forest.py
@@ -113,3 +113,12 @@ class RandomForest(BaseModel):
 
     def sample_functions(self, X_test, n_funcs=1):
         pass
+
+    def __getstate__(self):
+        sdict = self.__dict__.copy()
+        del sdict['reg_rng']  # delete not-pickleable objects
+        return sdict
+
+    def __setstate__(self, sdict):
+         self.__dict__.update(sdict)
+         self.reg_rng = reg.default_random_engine(sdict['rng'].randint(1000))


### PR DESCRIPTION
The rfr C++ random number generator is not pickle-able but is an attribute of the random forest model. 
To pickle the model we have to delete the rng before dumping and add it back after loading. 
Sadly there is no easy and robust way to also store the internal state of the rng, so we loose it.